### PR TITLE
fix: set font correctly in text input elements

### DIFF
--- a/src/render/canvas/canvas-renderer.ts
+++ b/src/render/canvas/canvas-renderer.ts
@@ -464,10 +464,10 @@ export class CanvasRenderer extends Renderer {
         }
 
         if (isTextInputElement(container) && container.value.length) {
-            const [fontFamily, fontSize] = this.createFontStyle(styles);
+            const [font, fontFamily, fontSize] = this.createFontStyle(styles);
             const { baseline } = this.fontMetrics.getMetrics(fontFamily, fontSize);
 
-            this.ctx.font = fontFamily;
+            this.ctx.font = font;
             this.ctx.fillStyle = asString(styles.color);
 
             this.ctx.textBaseline = 'alphabetic';
@@ -521,9 +521,9 @@ export class CanvasRenderer extends Renderer {
                     }
                 }
             } else if (paint.listValue && container.styles.listStyleType !== LIST_STYLE_TYPE.NONE) {
-                const [fontFamily] = this.createFontStyle(styles);
+                const [font] = this.createFontStyle(styles);
 
-                this.ctx.font = fontFamily;
+                this.ctx.font = font;
                 this.ctx.fillStyle = asString(styles.color);
 
                 this.ctx.textBaseline = 'middle';


### PR DESCRIPTION
**Summary**

While implementing Html2Canvas we noticed that not all input fields got the correct font or baseline calculations.
during investigations we noticed that the createFontStyle function returns 3 parameters (font, fontfamily & font size) while in some places it put the font in a fontfamily variable which was then used to calculate the baseline which failed.

This PR fixes/implements the following **bugs/features**

* [x] Bug 1
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

Explain the **motivation** for making this change. What existing problem does the pull request solve?
this solves our problem of our application using a custom font/font size/font family and text being displayed way too high in the canvas

**Test plan (required)**

i sadly wasn't able to get it to break in a jsfiddle, which means i wasn't able to make a test plan. but hopefully the small change is enough to see how it was semi broken ^^;

left is webpage, right is canvas/print
![image](https://github.com/user-attachments/assets/85ef0f5b-d12a-4057-9ddf-94eaab5b846c)

and with the fix it looks as following
![image](https://github.com/user-attachments/assets/d9a64bdb-35f4-4ddf-a430-d4234383934f)

the input field doesn't look perfect yet, but thats our css probably fucking up, so no worries :)

**Code formatting**

Please make sure that code adheres to the project code formatting. Running `npm run format` will automatically format your code correctly.

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
N/A
