### PR TITLE
feat: add the `customIsSameOrigin` option to support custom same-orig…

### DIFF
--- a/src/core/cache-storage.ts
+++ b/src/core/cache-storage.ts
@@ -31,6 +31,7 @@ export interface ResourceOptions {
     useCORS: boolean;
     allowTaint: boolean;
     proxy?: string;
+    customIsSameOrigin?: (this: void, src: string, oldFn: (src: string) => boolean) => boolean | Promise<boolean>;
 }
 
 export class Cache {
@@ -61,7 +62,10 @@ export class Cache {
     }
 
     private async loadImage(key: string) {
-        const isSameOrigin = CacheStorage.isSameOrigin(key);
+        const isSameOrigin: boolean =
+            typeof this._options.customIsSameOrigin === 'function'
+                ? await this._options.customIsSameOrigin(key, CacheStorage.isSameOrigin)
+                : CacheStorage.isSameOrigin(key);
         const useCORS =
             !isInlineImage(key) && this._options.useCORS === true && FEATURES.SUPPORT_CORS_IMAGES && !isSameOrigin;
         const useProxy =

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,8 @@ const renderElement = async (element: HTMLElement, opts: Partial<Options>): Prom
         allowTaint: opts.allowTaint ?? false,
         imageTimeout: opts.imageTimeout ?? 15000,
         proxy: opts.proxy,
-        useCORS: opts.useCORS ?? false
+        useCORS: opts.useCORS ?? false,
+        customIsSameOrigin: opts.customIsSameOrigin
     };
 
     const contextOptions = {

--- a/tests/reftests/options/custom-is-same-origin.html
+++ b/tests/reftests/options/custom-is-same-origin.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Custom isSameOrigin test</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <script type="text/javascript" src="../../test.js"></script>
+    <style>
+        body {
+            padding: 10px;
+        }
+        .image-container {
+            width: 200px;
+            height: 200px;
+            margin-bottom: 10px;
+            border: 1px solid #ccc;
+        }
+        img {
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
+        }
+        .flex {
+            display: flex;
+            gap: 10px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Custom isSameOrigin tests</h1>
+
+    <main class="flex">
+        <div>
+            <div class="image-container">
+                <img id="local-image" src="/tests/assets/image.svg" />
+            </div>
+            <p>Local image (same origin)</p>
+        </div>
+
+        <div>
+            <div class="image-container">
+                <img id="external-image" src="https://yorickshan.github.io/html2canvas-pro/logo.png" />
+            </div>
+            <p>External image (different origin)</p>
+        </div>
+
+        <div>
+            <div class="image-container">
+                <img id="redirect-image" src="/redirect-image" />
+            </div>
+            <p>Redirect image (simulates redirection)</p>
+        </div>
+    </main>
+
+    <!-- canvas container -->
+    <section id="canvas-container" class="flex" style="flex-direction: column; gap: 50px;"></section>
+
+    <script type="text/javascript">
+        window.dontRun = true;
+
+        const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+        const h2cTests = [{
+            name: 'With customIsSameOrigin forcing all to not be same origin',
+            options: {
+                useCORS: true,
+                logging: true,
+                customIsSameOrigin: (src, oldFn) => false
+            }
+        }, {
+            name: 'With customIsSameOrigin for handling redirect',
+            options: {
+                useCORS: true,
+                logging: true,
+                customIsSameOrigin: (src, oldFn) => {
+                    // Mark the redirect-image as not same origin
+                    if (src.includes('/redirect-image')) {
+                        return false;
+                    }
+                    return oldFn(src);
+                }
+            }
+        }, {
+            name: 'With async customIsSameOrigin check',
+            options: {
+                useCORS: true,
+                logging: true,
+                customIsSameOrigin: async (src, oldFn) => {
+                    if (src.includes('/redirect-image')) {
+                        // Wait briefly to simulate async check
+                        await sleep(50);
+                        return false;
+                    }
+                    return oldFn(src);
+                }
+            }
+        }];
+
+        // execute tests
+        async function runTests() {
+            const htmlContainer = document.querySelector("main");
+            const canvasContainer = document.querySelector('#canvas-container');
+
+            for (const test of h2cTests) {
+                await sleep(1000);
+                const canvas = await html2canvas(htmlContainer, test.options);
+                const resultDiv = document.createElement('div');
+                resultDiv.classList.add("flex")
+                const p = document.createElement('p');
+                p.innerText = test.name;
+                resultDiv.appendChild(p);
+                resultDiv.appendChild(canvas);
+                canvasContainer.appendChild(resultDiv);
+            }
+        }
+
+        runTests();
+    </script>
+</body>
+</html>

--- a/tests/server.ts
+++ b/tests/server.ts
@@ -16,10 +16,22 @@ export const app = express();
 app.use('/', serveIndex(path.resolve(__dirname, '../'), { icons: true }));
 app.use([/^\/src($|\/)/, '/'], express.static(path.resolve(__dirname, '../')));
 
+// Add route to handle redirect-image test case
+app.get('/redirect-image', (_req, res) => {
+    // Redirect to an external domain
+    res.redirect('https://yorickshan.github.io/html2canvas-pro/logo.png');
+});
+
 export const corsApp = express();
 corsApp.use('/proxy', proxy());
 corsApp.use('/cors', cors(), express.static(path.resolve(__dirname, '../')));
 corsApp.use('/', express.static(path.resolve(__dirname, '.')));
+
+// Add route to handle redirect-image test case in CORS app too
+corsApp.get('/redirect-image', (_req, res) => {
+    // Redirect to an external domain
+    res.redirect('https://yorickshan.github.io/html2canvas-pro/logo.png');
+});
 
 export const screenshotApp = express();
 screenshotApp.use(cors());


### PR DESCRIPTION
**Summary**

Added `customIsSameOrigin` option to allow customization of same-origin check logic.

This PR implements the following **features**

* [x] Add `customIsSameOrigin` configuration option to support custom same-origin checks

**Motivation**

In certain scenarios, users may need to customize the logic for determining whether resources are from the same origin, such as in specific proxy server environments or special network configurations. The default same-origin check logic may not be flexible enough, so this option allows users to provide their own checking function, thereby gaining better control over how resources are loaded.

**Test plan**

Added a test case that verifies the proper functioning of the custom same-origin check function. The test demonstrates how to override the default same-origin check logic using the `customIsSameOrigin` option.

**Code formatting**

Ran `npm run format` to ensure the code adheres to the project's formatting requirements.

**Closing issues**

Fixes #116