### PR TITLE
ci(deploy): fix `Missing download info for actions/upload-pages-artifact@v4`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build with VitePress
         run: npm run docs:build # or pnpm docs:build / yarn docs:build / bun run docs:build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/.vitepress/dist
 


### PR DESCRIPTION
**Summary**

fix `Missing download info for actions/upload-pages-artifact@v4` in git pages deployment by adjust upload-pages-artifact action version to v3

**Motivation** 

I noticed that the last adjustment to v4 was when modifying the `upload-artifact` in `.github/workflows/ci.yml`. 
It might have been an accidental operation that also changed the version of `upload-pages-artifact`. 
These are two different packages, and in fact, the highest version of `upload-pages-artifact` is only 3.0.1.

I noticed that the last adjustment to v4 was when modifying the `upload-artifact` in `.github/workflows/ci.yml`. (commit 
ef54137)

It might have been an accidental operation that also changed the version of `upload-pages-artifact`. 
These are two different packages, and in fact, the highest version of `upload-pages-artifact` is only 3.0.1.
