### PR TITLE
fix(document-cloner): use source document baseURI for background-imag…

### DIFF
--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -174,10 +174,11 @@ export class DocumentCloner {
             return iframe;
         });
         /**
-         * The baseURI of the document will be lost after documentClone.open().
-         * We save it before open() to preserve the original base URI for resource resolution.
-         * */
-        const baseUri = documentClone.baseURI;
+         * The base URI used for resolving relative URLs (e.g. background-image) in the clone.
+         * Must come from the source document: the iframe document is about:blank, so
+         * documentClone.baseURI would break getComputedStyle() for relative background URLs.
+         */
+        const baseUri = ownerDocument.baseURI;
         documentClone.open();
         const rawHTML = serializeDoctype(document.doctype) + '<html></html>';
         try {


### PR DESCRIPTION
Fixes #210. The iframe clone document resolves to about:blank, so using documentClone.baseURI broke relative background-image URLs in v2.x.