### PR TITLE
fix(text): keep range offsets aligned after text-transform

### DIFF
--- a/src/dom/text-container.ts
+++ b/src/dom/text-container.ts
@@ -9,6 +9,11 @@ export class TextContainer {
 
     constructor(context: Context, node: Text, styles: CSSParsedDeclaration) {
         this.text = transform(node.data, styles.textTransform);
+        // Range offsets below are based on transformed text; keep the node in sync
+        // when casing changes string length, for example "ß".toUpperCase() === "SS".
+        if (this.text.length !== node.data.length) {
+            node.data = this.text;
+        }
         this.textBounds = parseTextBounds(context, this.text, styles, node);
     }
 }

--- a/tests/reftests/text/text.html
+++ b/tests/reftests/text/text.html
@@ -130,6 +130,7 @@
     <li style="text-transform:capitalize;">text-transform: capitalize; (including foreign characters such as Öaäå)
     </li>
     <li style="text-transform:uppercase;">text-transform:uppercase;</li>
+    <li style="text-transform:uppercase;">text-transform:uppercase with length-changing ß;</li>
     <li style="text-transform:lowercase;">text-transform:lowercase;</li>
 </ul>
 <h3>&lt;h3&gt; misc text alignments</h3>


### PR DESCRIPTION
CSS text-transform can change string length, for example "ß".toUpperCase() becoming "SS". This keeps the cloned text node in sync before measuring Range bounds so transformed offsets cannot exceed the underlying node length.