### PR TITLE
fix(document-cloner): restore scroll after onclone

### DIFF
--- a/src/dom/document-cloner.ts
+++ b/src/dom/document-cloner.ts
@@ -139,18 +139,6 @@ export class DocumentCloner {
             this.scrolledElements.forEach(restoreNodeScroll);
             if (cloneWindow) {
                 cloneWindow.scrollTo(windowSize.left, windowSize.top);
-                if (
-                    /AppleWebKit/g.test(navigator.userAgent) &&
-                    (cloneWindow.scrollY !== windowSize.top || cloneWindow.scrollX !== windowSize.left)
-                ) {
-                    this.context.logger.warn('Unable to restore scroll position for cloned document');
-                    this.context.windowBounds = this.context.windowBounds.add(
-                        cloneWindow.scrollX - windowSize.left,
-                        cloneWindow.scrollY - windowSize.top,
-                        0,
-                        0
-                    );
-                }
             }
 
             const onclone = this.options.onclone;
@@ -170,9 +158,24 @@ export class DocumentCloner {
             }
 
             if (typeof onclone === 'function') {
-                return Promise.resolve()
-                    .then(() => onclone(documentClone, referenceElement))
-                    .then(() => iframe);
+                await Promise.resolve().then(() => onclone(documentClone, referenceElement));
+            }
+
+            // onclone can change layout above the viewport and trigger browser scroll
+            // anchoring. Reapply the requested offset after the callback so element
+            // bounds stay aligned with the window bounds used by the renderer.
+            cloneWindow.scrollTo(windowSize.left, windowSize.top);
+            if (
+                /AppleWebKit/g.test(navigator.userAgent) &&
+                (cloneWindow.scrollY !== windowSize.top || cloneWindow.scrollX !== windowSize.left)
+            ) {
+                this.context.logger.warn('Unable to restore scroll position for cloned document');
+                this.context.windowBounds = this.context.windowBounds.add(
+                    cloneWindow.scrollX - windowSize.left,
+                    cloneWindow.scrollY - windowSize.top,
+                    0,
+                    0
+                );
             }
 
             return iframe;

--- a/tests/reftests/options/onclone-scroll.html
+++ b/tests/reftests/options/onclone-scroll.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>onclone scroll position test</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <script>
+        h2cOptions = {
+            x: 0,
+            y: 600,
+            width: 800,
+            height: 600,
+            scrollX: 0,
+            scrollY: 600,
+            onclone: function(document) {
+                var spacer = document.createElement('div');
+                spacer.id = 'clone-spacer';
+                spacer.style.background = 'rgb(255, 215, 0)';
+                spacer.style.height = '300px';
+                spacer.style.overflowAnchor = 'none';
+
+                var content = document.querySelector('#content');
+                content.parentNode.insertBefore(spacer, content);
+            }
+        };
+    </script>
+    <script type="text/javascript" src="../../test.js"></script>
+    <style>
+        body, html {
+            margin: 0;
+            padding: 0;
+            scroll-behavior: auto;
+        }
+
+        #before {
+            background: rgb(200, 30, 30);
+            height: 500px;
+            overflow-anchor: none;
+        }
+
+        #content {
+            background: rgb(20, 160, 90);
+            box-sizing: border-box;
+            height: 600px;
+            padding-top: 120px;
+        }
+
+        #anchor {
+            color: white;
+            font: 32px sans-serif;
+            margin: 0;
+            padding: 0 30px;
+        }
+
+        #after {
+            background: rgb(210, 30, 160);
+            height: 700px;
+        }
+    </style>
+</head>
+<body>
+    <div id="before"></div>
+    <main id="content">
+        <h1 id="anchor">Visible scroll anchor</h1>
+    </main>
+    <div id="after"></div>
+</body>
+</html>


### PR DESCRIPTION
A similar PR may already be submitted!
I searched open and closed pull requests for `onclone`, `scroll`, `scroll position`, `scrollY`, `windowBounds`, and `DocumentCloner`; no PR covers this behavior.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

Before opening a pull request, please make sure all the tests pass locally by running `pnpm test`.

**Summary**

This PR fixes/implements the following **bugs/features**

* [x] Preserve the configured clone viewport when `onclone` changes layout above it
* [x] Check the existing WebKit scroll fallback against the final clone position
* [ ] Feature
* [ ] Breaking changes

`DocumentCloner.toIFrame()` currently scrolls the hidden iframe before invoking `onclone`. A callback that changes layout above the viewport can activate browser scroll anchoring after that initial positioning. The renderer still measures against the original `Context.windowBounds`, so the shifted clone and the requested crop use different coordinate systems.

This change keeps the existing initial positioning, callback scheduling, and async callback support. Once `onclone` has settled, it reapplies the caller's requested `scrollX` / `scrollY` and then performs the existing WebKit mismatch adjustment against that final position.

**Test plan (required)**

Added `tests/reftests/options/onclone-scroll.html`, which:

1. requests an 800×600 crop at `scrollY: 600`;
2. places a text anchor near that viewport;
3. inserts a 300 px gold spacer above it in `onclone`.

On unmodified v2.3.9/current `main`, Chrome scroll anchoring changes the clone from `600` to `900`; the canvas incorrectly starts with the green content section. With this patch, the clone ends at `600`; the first 200 CSS pixels are gold and the remainder is green, as requested. The same expected gold→green landmark was verified from the generated Chrome and Firefox reftest artifacts (including Firefox DPR 2).

Local checks:

* `pnpm build`
* `pnpm test` — 1,158 unit tests and 212 browser reftests passed (Chrome 151 and Firefox 153)
* `pnpm commitlint`
* `pnpm exec prettier --check src/dom/document-cloner.ts`
* `git diff --check`

Remote verification: [CI run 32493301438](https://github.com/yorickshan/html2canvas-pro/actions/runs/32493301438) passed Build, Test, CodeQL, Linux Chrome, Linux Firefox, and macOS Safari. The downloaded reftest artifact from each browser was 800×600 and had the same exact landmarks: gold at CSS y=20/180 and green at y=220/550.

An additional downstream integration smoke loaded this PR's bundle while disabling that consumer's own scroll-anchoring stabilization and final clone `scrollTo`. Its float/clearfix/pseudo-element viewport fixture remained aligned in 8/8 Playwright cases: Chromium, Chromium DPR 2, Firefox, and WebKit, each with `overflow: visible` and `overflow: auto`.

**Code formatting**

The changed TypeScript file passes the repository's Prettier and ESLint hooks; the commit passes Commitlint.

**Closing issues**

Fixes #231
