### PR TITLE
test(canvas-renderer): cover offset inset shadow masks

### DIFF
--- a/src/render/canvas/__tests__/canvas-renderer.test.ts
+++ b/src/render/canvas/__tests__/canvas-renderer.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Context } from '../../../core/context';
+import { Vector } from '../../vector';
+import { createMockContext } from '../../__mocks__/canvas';
+import { CanvasRenderer } from '../canvas-renderer';
+
+describe('CanvasRenderer', () => {
+    it('anchors masks to an offset render origin', () => {
+        const ctx = createMockContext();
+        const canvas = {
+            getContext: vi.fn().mockReturnValue(ctx)
+        } as unknown as HTMLCanvasElement;
+        const context = {
+            logger: {
+                debug: vi.fn()
+            }
+        } as unknown as Context;
+        const renderer = new CanvasRenderer(context, {
+            backgroundColor: null,
+            canvas,
+            height: 300,
+            scale: 1,
+            width: 400,
+            x: 300,
+            y: 200
+        });
+
+        renderer.mask([new Vector(480, 240), new Vector(680, 240), new Vector(680, 440), new Vector(480, 440)]);
+
+        expect(ctx.moveTo).toHaveBeenNthCalledWith(1, 300, 200);
+        expect(ctx.lineTo).toHaveBeenNthCalledWith(1, 700, 200);
+        expect(ctx.lineTo).toHaveBeenNthCalledWith(2, 700, 500);
+        expect(ctx.lineTo).toHaveBeenNthCalledWith(3, 300, 500);
+        expect(ctx.lineTo).toHaveBeenNthCalledWith(4, 300, 200);
+    });
+});

--- a/tests/reftests/background/box-shadow-offset-element.html
+++ b/tests/reftests/background/box-shadow-offset-element.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Inset box-shadow on an offset capture target</title>
+        <script type="text/javascript" src="../../test.js"></script>
+        <style>
+            html,
+            body {
+                margin: 0;
+                min-height: 700px;
+                min-width: 900px;
+            }
+
+            #target {
+                background: #fff;
+                height: 300px;
+                left: 300px;
+                position: absolute;
+                top: 200px;
+                width: 400px;
+            }
+
+            #child {
+                background: #0a0;
+                box-shadow: inset 0 0 0 4px #f00;
+                height: 200px;
+                left: 180px;
+                position: absolute;
+                top: 40px;
+                width: 200px;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="target">
+            <div id="child"></div>
+        </div>
+        <script>
+            var forceElement = document.querySelector('#target');
+            h2cSelector = forceElement;
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
A similar PR may already be submitted!
I searched open and closed pull requests for `#230`, `mask()`, offset capture targets, inset `box-shadow`, and `CanvasRenderer`; no PR adds regression coverage for this behavior.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

Before opening a pull request, please make sure all the tests pass locally by running `pnpm test`.

**Summary**

This PR fixes/implements the following **bugs/features**

* [x] Unit coverage for anchoring the mask rectangle at `options.x` / `options.y`
* [x] Browser reftest for an inset shadow inside an offset capture target
* [ ] Feature
* [ ] Breaking changes

The runtime fix reported in #230 was already applied in commit `67d21ac69d691c0ee78f007bbe218d4f03a3231d` and shipped in v2.3.9. The issue remains open, however, and that fix did not include a regression test.

This PR keeps the released implementation unchanged. It adds a focused unit test that verifies the enclosing mask rectangle uses the render origin, plus a reftest based on the reporter's 400×300 target at `(300, 200)` with a 200×200 child and a 4 px inset ring. Together they protect both the coordinate contract and the visible browser result.

**Test plan (required)**

Red/green regression proof:

* With the pre-v2.3.9 `(0, 0)` mask implementation, the focused test fails: expected the first `moveTo` at `(300, 200)`, received `(0, 0)`.
* With v2.3.9/current `main`, the focused test passes.

Local browser reftest artifacts on current `main`:

* Chrome 151, DPR 1: 400×300 canvas; 3,136 red ring pixels, 36,864 green interior pixels, 80,000 white background pixels, 0 other pixels.
* Firefox 153, DPR 2: 800×600 canvas; the exact 4× pixel counts expected at DPR 2.

Local checks:

* `pnpm build`
* `pnpm test` — 86 unit-test files / 1,159 unit tests and 212 browser reftests passed (Chrome 151 and Firefox 153)
* `pnpm commitlint`
* `pnpm exec prettier --check src/render/canvas/__tests__/canvas-renderer.test.ts tests/reftests/background/box-shadow-offset-element.html`
* `git diff --check`

Remote verification: [CI run 32495905522](https://github.com/yorickshan/html2canvas-pro/actions/runs/32495905522) passed Build, Test, CodeQL, Linux Chrome, Linux Firefox, and macOS Safari. The downloaded artifact from Chrome 151, Firefox 153, and Safari 26.5.2 was 400×300 in every browser with the exact expected counts: 3,136 red ring pixels, 36,864 green interior pixels, 80,000 white background pixels, and 0 other pixels.

**Code formatting**

Both added files pass the repository's Prettier and ESLint hooks; the commit passes Commitlint.

**Closing issues**

Closes #230
