### PR TITLE
fix(canvas-renderer): preserve constrained input text

### DIFF
--- a/src/render/canvas/__tests__/content-renderer-form.test.ts
+++ b/src/render/canvas/__tests__/content-renderer-form.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { Bounds } from '../../../css/layout/bounds';
+import { inputTextClipBounds } from '../content-renderer';
+
+describe('inputTextClipBounds (issue #232)', () => {
+    it('uses the padding box vertically when the content box is shorter than the font', () => {
+        const contentBounds = new Bounds(9, 9, 382, 7);
+        const paddingBounds = new Bounds(1, 1, 398, 23);
+
+        expect(inputTextClipBounds(contentBounds, paddingBounds, 17)).toEqual(new Bounds(9, 1, 382, 23));
+    });
+
+    it('keeps the content box when it can contain the font', () => {
+        const contentBounds = new Bounds(9, 9, 382, 17);
+        const paddingBounds = new Bounds(1, 1, 398, 33);
+
+        expect(inputTextClipBounds(contentBounds, paddingBounds, 17)).toBe(contentBounds);
+    });
+});

--- a/src/render/canvas/__tests__/font-utils.test.ts
+++ b/src/render/canvas/__tests__/font-utils.test.ts
@@ -1,5 +1,5 @@
 import { strictEqual } from 'assert';
-import { measureBaseline } from '../font-utils';
+import { measureBaseline, measureFontMetrics } from '../font-utils';
 
 describe('measureBaseline', () => {
     const createMockCtx = (overrides: Record<string, unknown> = {}) => {
@@ -9,7 +9,9 @@ describe('measureBaseline', () => {
                 return {
                     width: 30,
                     fontBoundingBoxAscent: 14,
+                    fontBoundingBoxDescent: 3,
                     actualBoundingBoxAscent: 14,
+                    actualBoundingBoxDescent: 2,
                     ...overrides
                 };
             }
@@ -50,5 +52,46 @@ describe('measureBaseline', () => {
         const ctx = createMockCtx({ fontBoundingBoxAscent: undefined, actualBoundingBoxAscent: undefined });
         const result = measureBaseline(ctx, undefined as unknown as number);
         strictEqual(result, undefined);
+    });
+});
+
+describe('measureFontMetrics', () => {
+    const createMockCtx = (overrides: Record<string, unknown> = {}) =>
+        ({
+            measureText: () => ({
+                fontBoundingBoxAscent: 14,
+                fontBoundingBoxDescent: 3,
+                actualBoundingBoxAscent: 12,
+                actualBoundingBoxDescent: 2,
+                ...overrides
+            })
+        }) as unknown as CanvasRenderingContext2D;
+
+    it('uses the font bounding box when both font metrics are available', () => {
+        const metrics = measureFontMetrics(createMockCtx(), 16);
+        strictEqual(metrics.baseline, 14);
+        strictEqual(metrics.height, 17);
+    });
+
+    it('uses the actual glyph box when font bounding metrics are unavailable', () => {
+        const metrics = measureFontMetrics(
+            createMockCtx({ fontBoundingBoxAscent: undefined, fontBoundingBoxDescent: undefined }),
+            16
+        );
+        strictEqual(metrics.baseline, 12);
+        strictEqual(metrics.height, 14);
+    });
+
+    it('uses the fallback height when neither complete metric pair is available', () => {
+        const metrics = measureFontMetrics(
+            createMockCtx({
+                fontBoundingBoxDescent: undefined,
+                actualBoundingBoxAscent: undefined,
+                actualBoundingBoxDescent: undefined
+            }),
+            16
+        );
+        strictEqual(metrics.baseline, 14);
+        strictEqual(metrics.height, 16);
     });
 });

--- a/src/render/canvas/content-renderer.ts
+++ b/src/render/canvas/content-renderer.ts
@@ -19,10 +19,10 @@ import { Bounds } from '../../css/layout/bounds';
 import { BoundCurves } from '../bound-curves';
 import { TextBounds } from '../../css/layout/text';
 import { Vector } from '../vector';
-import { contentBox } from '../box-sizing';
+import { contentBox, paddingBox } from '../box-sizing';
 import { Context } from '../../core/context';
 import { TextRenderer } from './text-renderer';
-import { measureBaseline } from './font-utils';
+import { measureFontMetrics } from './font-utils';
 import { IMAGE_RENDERING } from '../../css/property-descriptors/image-rendering';
 import { TEXT_ALIGN } from '../../css/property-descriptors/text-align';
 import { DISPLAY } from '../../css/property-descriptors/display';
@@ -165,13 +165,18 @@ export function renderFormElements(
         const [font] = textRenderer.createFontStyle(styles);
         // Use Canvas API to measure baseline from the actual rendered font
         ctx.font = font;
-        const baseline = measureBaseline(ctx, getAbsoluteValue(styles.fontSize, 0));
+        const fontSizeValue = getAbsoluteValue(styles.fontSize, 0);
+        const { baseline, height: fontHeight } = measureFontMetrics(ctx, fontSizeValue);
         const isPlaceholder = container instanceof InputElementContainer && container.isPlaceholder;
         ctx.fillStyle = isPlaceholder ? asString(PLACEHOLDER_COLOR) : asString(styles.color);
         ctx.textBaseline = 'alphabetic';
         ctx.textAlign = canvasTextAlign(container.styles.textAlign);
 
         const bounds = contentBox(container);
+        const clipBounds =
+            container instanceof InputElementContainer
+                ? inputTextClipBounds(bounds, paddingBox(container), fontHeight)
+                : bounds;
         let x = 0;
         switch (container.styles.textAlign) {
             case TEXT_ALIGN.CENTER:
@@ -184,18 +189,17 @@ export function renderFormElements(
 
         let verticalOffset = 0;
         if (container instanceof InputElementContainer) {
-            const fontSizeValue = getAbsoluteValue(styles.fontSize, 0);
-            verticalOffset = (bounds.height - fontSizeValue) / 2;
+            verticalOffset = (bounds.height - fontHeight) / 2;
         }
 
         const textBounds = bounds.add(x, verticalOffset, 0, 0);
 
         ctx.save();
         pathFn([
-            new Vector(bounds.left, bounds.top),
-            new Vector(bounds.left + bounds.width, bounds.top),
-            new Vector(bounds.left + bounds.width, bounds.top + bounds.height),
-            new Vector(bounds.left, bounds.top + bounds.height)
+            new Vector(clipBounds.left, clipBounds.top),
+            new Vector(clipBounds.left + clipBounds.width, clipBounds.top),
+            new Vector(clipBounds.left + clipBounds.width, clipBounds.top + clipBounds.height),
+            new Vector(clipBounds.left, clipBounds.top + clipBounds.height)
         ]);
         ctx.clip();
 
@@ -209,7 +213,6 @@ export function renderFormElements(
             bounds.width,
             styles.whiteSpace === WHITE_SPACE.PRE || styles.whiteSpace === WHITE_SPACE.NOWRAP
         );
-        const fontSizeValue = getAbsoluteValue(styles.fontSize, 0);
         const lineHeight = computeLineHeight(styles.lineHeight, fontSizeValue);
 
         lines.forEach((line, index) => {
@@ -236,6 +239,18 @@ export function renderFormElements(
         ctx.textAlign = 'left';
     }
 }
+
+/**
+ * Native single-line inputs may paint value text into their padding area when
+ * fixed height and vertical padding leave a content box shorter than the font.
+ * Preserve the content box horizontally, but avoid clipping those glyphs to the
+ * collapsed vertical content box.
+ * @internal exported for testing
+ */
+export const inputTextClipBounds = (contentBounds: Bounds, inputPaddingBox: Bounds, fontHeight: number): Bounds =>
+    contentBounds.height < fontHeight
+        ? new Bounds(contentBounds.left, inputPaddingBox.top, contentBounds.width, inputPaddingBox.height)
+        : contentBounds;
 
 /**
  * Split text into lines that fit the given pixel width, preserving hard line

--- a/src/render/canvas/font-utils.ts
+++ b/src/render/canvas/font-utils.ts
@@ -1,8 +1,8 @@
 /**
  * Font measurement utility
  *
- * Provides Canvas API-based baseline measurement that works correctly with
- * webfonts (which may not be loaded in the original document) and system fonts.
+ * Provides Canvas API-based font measurement that works correctly with webfonts
+ * (which may not be loaded in the original document) and system fonts.
  *
  * Fallback chain:
  *   1. fontBoundingBoxAscent — font-level metric (Chrome 99+, FF 116+, Safari 17.4+)
@@ -12,6 +12,37 @@
 
 const SAMPLE_TEXT = 'Mg'; // characters with both ascender and descender
 
+export interface CanvasFontMetrics {
+    baseline: number;
+    height: number;
+}
+
+const isValidMetric = (value: number | undefined): value is number => value !== undefined && !Number.isNaN(value);
+
+/**
+ * Measure the baseline ascent and full font box for the currently set font.
+ */
+export const measureFontMetrics = (ctx: CanvasRenderingContext2D, fallback: number): CanvasFontMetrics => {
+    const tm = ctx.measureText(SAMPLE_TEXT);
+    const fontMetrics = tm as TextMetrics & {
+        fontBoundingBoxAscent?: number;
+        fontBoundingBoxDescent?: number;
+    };
+    const baseline = isValidMetric(fontMetrics.fontBoundingBoxAscent)
+        ? fontMetrics.fontBoundingBoxAscent
+        : isValidMetric(tm.actualBoundingBoxAscent)
+          ? tm.actualBoundingBoxAscent
+          : fallback;
+    const height =
+        isValidMetric(fontMetrics.fontBoundingBoxAscent) && isValidMetric(fontMetrics.fontBoundingBoxDescent)
+            ? fontMetrics.fontBoundingBoxAscent + fontMetrics.fontBoundingBoxDescent
+            : isValidMetric(tm.actualBoundingBoxAscent) && isValidMetric(tm.actualBoundingBoxDescent)
+              ? tm.actualBoundingBoxAscent + tm.actualBoundingBoxDescent
+              : fallback;
+
+    return { baseline, height };
+};
+
 /**
  * Measure the baseline ascent for the currently set font.
  *
@@ -20,8 +51,5 @@ const SAMPLE_TEXT = 'Mg'; // characters with both ascender and descender
  * @returns The distance from the text baseline to the top of the bounding box
  */
 export const measureBaseline = (ctx: CanvasRenderingContext2D, fallback: number): number => {
-    const tm = ctx.measureText(SAMPLE_TEXT);
-    const fmAscent = (tm as { fontBoundingBoxAscent?: number }).fontBoundingBoxAscent;
-    const ascent = fmAscent !== undefined && !Number.isNaN(fmAscent) ? fmAscent : tm.actualBoundingBoxAscent;
-    return ascent !== undefined && !Number.isNaN(ascent) ? ascent : fallback;
+    return measureFontMetrics(ctx, fallback).baseline;
 };

--- a/tests/reftests/webcomponents/input-overconstrained-padding.html
+++ b/tests/reftests/webcomponents/input-overconstrained-padding.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Web component input with over-constrained vertical padding</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <script>
+            class PaddedTextField extends HTMLElement {
+                constructor() {
+                    super();
+                    const shadow = this.attachShadow({ mode: 'open' });
+                    const style = document.createElement('style');
+                    style.textContent = `
+                        input {
+                            box-sizing: border-box;
+                            width: 100%;
+                            height: 100%;
+                            padding: 8px;
+                            border: 1px solid #d4d5d8;
+                            border-radius: 8px;
+                            background: #eef0f5;
+                            color: #111;
+                            font: 600 14px/17.5px system-ui, sans-serif;
+                        }
+                    `;
+                    this.input = document.createElement('input');
+                    shadow.append(style, this.input);
+                }
+
+                connectedCallback() {
+                    this.input.value = this.getAttribute('value') || '';
+                }
+            }
+
+            customElements.define('padded-text-field', PaddedTextField);
+        </script>
+        <script type="text/javascript" src="../../test.js"></script>
+        <style>
+            body,
+            html {
+                margin: 0;
+            }
+
+            padded-text-field {
+                display: block;
+                width: 400px;
+                margin-bottom: 18px;
+            }
+        </style>
+    </head>
+    <body>
+        <padded-text-field
+            style="height: 25px"
+            value="Web component field, outer height 25px"
+        ></padded-text-field>
+        <padded-text-field
+            style="height: 30px"
+            value="Web component field, outer height 30px"
+        ></padded-text-field>
+        <padded-text-field
+            style="height: 35px"
+            value="Web component field, outer height 35px"
+        ></padded-text-field>
+    </body>
+</html>


### PR DESCRIPTION
A similar PR may already be submitted!
I searched open and closed pull requests for `#232`, `dwc-field`, `input padding`, `clipped input`, `font metrics`, and `web component layout`; no PR covers this behavior. PR #233 only changes clone scroll restoration, while PR #234 adds inset-shadow regression tests without changing runtime code.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

Before opening a pull request, please make sure all the tests pass locally by running `pnpm test`.

**Summary**

This PR fixes the following **bug**:

* [x] Preserve and vertically align text in single-line inputs whose fixed height and vertical padding leave a content box shorter than the font.
* [x] Cover the reported custom-element/Shadow DOM surface with a self-contained reftest.
* [ ] Breaking changes

Issue #232 reproduces with `dwc-field`, but the layout failure is not specific to that component or to Shadow DOM. A reduced native `<input>` with `box-sizing: border-box`, a fixed height, and `8px` vertical padding shows the same clipping.

The canvas renderer currently clips input text to the CSS content box. For the reported 25px field, that box is only 7px high, so most of a 14px system-font value is discarded. It also centers the value using `font-size`, even though the font's Canvas ascent and descent form a taller 17px box.

This change:

* measures the full font box alongside the existing baseline;
* uses that measured height to center single-line input values;
* retains content-box clipping horizontally, but uses the input padding box vertically only when the content box cannot contain the font; and
* leaves textarea and select clipping unchanged.

No component-specific selector or Shadow DOM special case is introduced.

**Test plan (required)**

The new `tests/reftests/webcomponents/input-overconstrained-padding.html` fixture defines a minimal open-shadow-root custom element containing 25px, 30px, and 35px inputs with the reported font and padding constraints.

Manual verification was also performed against the reporter's `dwc-field` attachment, with the component distribution pinned to commit `f111c40ffaca40d58075902eb76d19b579ca3e97` and html2canvas-pro built from this branch:

* Before: the 25px value is heavily clipped and the remaining values render too low.
* After: all three values are complete and vertically aligned with native Chrome rendering.
* Pixel mismatch against the native 400x201 Chrome capture falls from 2,133 pixels to 354 pixels at a 0.1 pixelmatch threshold; the remainder is antialiasing and native-control border detail.

Local checks:

* `pnpm build`
* `pnpm test` — 1,163 unit tests and 212 browser/reftests pass (106 Chrome, 106 Firefox)
* Prettier, ESLint, and commitlint pass

Remote verification: [CI run 32499769663](https://github.com/yorickshan/html2canvas-pro/actions/runs/32499769663) passed Build, Test, CodeQL, Linux Chrome, Linux Firefox, and macOS Safari. The downloaded 800x600 reftest artifacts from Chrome 151, Firefox 153, and Safari 26.5.2 each render complete, vertically aligned values at all three constrained heights.

**Code formatting**

Code was formatted with the project's Prettier configuration and passes ESLint.

**Closing issues**

Fixes #232
